### PR TITLE
Feat/plan info in response and semantic version GitHub tag checking

### DIFF
--- a/app.py
+++ b/app.py
@@ -283,7 +283,7 @@ def fetch_active_upgrade_proposals(rest_url, network, network_repo_semver_tags):
                 if len(versions) == 0:
                     #fallback to naive search across whole message dump
                     versions = SEMANTIC_VERSION_PATTERN.findall(content_dump)
-                
+
                 version = find_best_semver_for_versions(network, versions, network_repo_semver_tags)
                 try:
                     height = int(plan.get("height", 0))
@@ -349,7 +349,7 @@ def fetch_network_repo_tags(network, network_repo):
             if not repo_name or not repo_owner:
                 print(f"Could not parse github repo name or owner for {network}")
                 return []
-            
+
             tags_url = GITHUB_API_URL + f"/repos/{repo_owner}/{repo_name}/tags"
             tags = requests.get(tags_url)
             return list(map(lambda tag: tag["name"], tags.json()))
@@ -387,7 +387,7 @@ def get_network_repo_semver_tags(network, network_repo_url):
 def find_best_semver_for_versions(network, network_version_strings, network_repo_semver_tags):
     if len(network_repo_semver_tags) == 0:
         return max(network_version_strings, key=len)
-    
+
     try:
         # find version matches in the repo tags
         possible_semvers = []
@@ -407,7 +407,7 @@ def find_best_semver_for_versions(network, network_version_strings, network_repo
             elif version_string.count(".") == 1:
                 contains_patch_version = False
                 version_string = version_string + ".0"
-            
+
             current_semver = semantic_version.Version(version_string)
 
             for semver_tag in network_repo_semver_tags:
@@ -468,7 +468,7 @@ def fetch_data_for_network(network, network_type, repo_path):
 
     network_repo_url = data.get("codebase", {}).get("git_repo", None)
     network_repo_semver_tags = []
-    
+
     if network_repo_url is not None:
         network_repo_semver_tags = get_network_repo_semver_tags(network, network_repo_url)
     else:

--- a/app.py
+++ b/app.py
@@ -3,7 +3,6 @@ import re
 from datetime import datetime
 from datetime import timedelta
 from random import shuffle
-import traceback
 
 # import logging
 import threading
@@ -618,7 +617,6 @@ def update_data():
             ).total_seconds()  # Calculate the elapsed time in case of an error
             print(f"Error in update_data loop after {elapsed_time} seconds: {e}")
             print("Error encountered. Sleeping for 1 minute before retrying...")
-            traceback.print_exc(e)
             sleep(60)
 
 

--- a/app.py
+++ b/app.py
@@ -471,14 +471,11 @@ def fetch_data_for_network(network, network_type, repo_path):
             info = json.loads(upgrade_plan.get("info", "{}"))
             binaries = info.get("binaries", {})
 
-            estimated_upgrade_time = info.get("time", None)
-
             # Include the expanded information in the output data
             output_data["upgrade_plan"] = {
                 "height": upgrade_plan.get("height", None),
                 "binaries": binaries,
                 "name": upgrade_plan.get("name", None),
-                "time": estimated_upgrade_time,
                 "upgraded_client_state": upgrade_plan.get("upgraded_client_state", None),
             }
             break

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Flask-Caching==2.0.2
 requests==2.26.0
 urllib3==1.26.7
 gunicorn==20.1.0
+semantic-version==2.10.0


### PR DESCRIPTION
### Plan Info in Response

This PR adds the plan info object into the response.

When the "source" is `current_upgrade_plan`, we include the parsed upgrade plan pulled from the plan endpoint:

```json
{
    "type": "mainnet",
    "network": "cosmoshub",
    "rpc_server": "https://cosmos-rpc.quickapi.com:443",
    "rest_server": "https://cosmoshub-api.lavenderfive.com:443",
    "latest_block_height": 16947875,
    "upgrade_found": true,
    "upgrade_name": "v12",
    "source": "current_upgrade_plan",
    "upgrade_block_height": 16985500,
    "estimated_upgrade_time": "2023-09-13T12:08:55.648530",
    "upgrade_plan": {
      "height": "16985500",
      "binaries": {
        "darwin/amd64": "https://github.com/cosmos/gaia/releases/download/v12.0.0/gaiad-v12.0.0-darwin-amd64?checksum=sha256:1b76a7b2ee9bd739cd28de6e380248f276c678d8f9cab1fc2fe17fce07389693",
        "darwin/arm64": "https://github.com/cosmos/gaia/releases/download/v12.0.0/gaiad-v12.0.0-darwin-arm64?checksum=sha256:20e81d813f942ed3114c6953016b9e24f0946b08e34f0da9c13bcb7276719130",
        "linux/amd64": "https://github.com/cosmos/gaia/releases/download/v12.0.0/gaiad-v12.0.0-linux-amd64?checksum=sha256:d67e91bda37c94f2efacba0f97bcbdb8931e9dbc457d1ce3f1e60a71d1b1b7dd",
        "linux/arm64": "https://github.com/cosmos/gaia/releases/download/v12.0.0/gaiad-v12.0.0-linux-arm64?checksum=sha256:aee279a6aedf8e83e59487c2006e72e496f73c36a882c44b3cc20969c3d237fb",
        "windows/amd64": "https://github.com/cosmos/gaia/releases/download/v12.0.0/gaiad-v12.0.0-windows-amd64.exe?checksum=sha256:7d970cd3f138b5ce8fe78a8209a5907fcfec6fb717434244010381cdd6b4cd32",
        "windows/arm64": "https://github.com/cosmos/gaia/releases/download/v12.0.0/gaiad-v12.0.0-windows-arm64.exe?checksum=sha256:b54c9c7e1c7bb36fc78cac294d86f8836e2dc02d747abc84d68062615a0512df"
      },
      "name": "v12",
      "upgraded_client_state": null
    },
    "version": "v12.0.0",
    "error": null
  }
```

### Network Repo Tags Checking for Version

This PR adds the simple [semantic-version](https://pypi.org/project/semantic-version/) Python package for parsing semantic versions.

This package is used in the following way: 

1. Use the codebase URL from the chain registry to pull down the current repo tags. These are cached per-repo url for 600 seconds to prevent external API throttling.
2. Get the possible version strings from the endpoints
3. Pass these to a semantic version checker that:
    * Finds possible semver matches between the parsed data and the network repo tags
    * Use the *highest semver* found in the matches

This fixes a known issue in the `secret` network where they are including other repo version tags in the plan description that was making the version be incorrect.

Secret now looks like this:

```json
{
    "type": "mainnet",
    "network": "secretnetwork",
    "rpc_server": "https://secretnetwork-rpc.lavenderfive.com:443",
    "rest_server": "https://secretnetwork-api.highstakes.ch:1317/",
    "latest_block_height": 10589028,
    "upgrade_found": true,
    "upgrade_name": "v1.11",
    "source": "active_upgrade_proposals",
    "upgrade_block_height": 10615300,
    "estimated_upgrade_time": "2023-09-12T14:05:53.051747",
    "upgrade_plan": null,
    "version": "v1.11.0",
    "error": null
  }
```

Closes #18 