### PR TITLE
Feat/production ready build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,3 @@ COPY . /app/
 
 # Expose port 5000 for the Flask app to listen on when running within the container
 EXPOSE 5000
-
-# Define the command to start the container. Use gunicorn as the WSGI server to serve the Flask app
-# CMD ["gunicorn", "--bind", "0.0.0.0:5000", "app:app"]
-CMD ["python", "app.py"]

--- a/app.py
+++ b/app.py
@@ -795,7 +795,7 @@ def get_app_args():
     app_role_subparsers = parser.add_subparsers(title='subcommands',
         description='valid app roles to run',
         help='runs the application in various configurations', dest='command')
-    
+
     # debug mode runs the application as a development server, with the cache setup as a simple in Python cache
     app_role_subparsers.add_parser('debug')
     # reader mode runs the application as a production Flask server, with the cache setup as an external store that is read from

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   reader:
-    build: 
+    build:
       context: .
     ports:
       - "5000:5000"
@@ -8,7 +8,7 @@ services:
       - cache-volume:/var/lib/cache
     command: ["gunicorn", "--bind", "0.0.0.0:5000", "-w", "4", "app:get_production_flask_app(\"/var/lib/cache\")"]
   writer:
-    build: 
+    build:
       context: .
     volumes:
       - cache-volume:/var/lib/cache

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,18 @@
+services:
+  reader:
+    build: 
+      context: .
+    ports:
+      - "5000:5000"
+    volumes:
+      - cache-volume:/var/lib/cache
+    command: ["gunicorn", "--bind", "0.0.0.0:5000", "-w", "4", "app:get_production_flask_app(\"/var/lib/cache\")"]
+  writer:
+    build: 
+      context: .
+    volumes:
+      - cache-volume:/var/lib/cache
+    command: ["python", "app.py", "writer", "--cache-location", "/var/lib/cache"]
+
+volumes:
+  cache-volume:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests==2.26.0
 urllib3==1.26.7
 gunicorn==20.1.0
 semantic-version==2.10.0
+Werkzeug==2.2.2


### PR DESCRIPTION
This PR adds a bit of code organization and features to do the following:

1. Add argparse usage to define three app subcommands: debug, reader, writer
2. Add different app run modes for the three subcommands:
    * `python app.py debug`: runs the application the same as it has been running
    * `python app.py reader`: runs the Flask application only with a FileSystem cache that Flask reads data from
    * `python app.py writer`: runs just the data update cycle with a FileSystem cache that the process writes to
3. Move Flask app building into Factory functions, which will provide `gunicorn` with a Flask app to get

This also adds a docker-compose.yaml file with:

1. Two services, one for a gunicorn build running the Flask reader process and one for the data writer
2. A shared volume that the cache location is pointing to, allowing the systems to use the same FS cache for reading and writing