### PR TITLE
patch/result key check in RPC time response

### DIFF
--- a/app.py
+++ b/app.py
@@ -179,9 +179,14 @@ def get_latest_block_height_rpc(rpc_url):
         response = requests.get(f"{rpc_url}/status", timeout=1)
         response.raise_for_status()
         data = response.json()
+        
+        if "result" in data.keys():
+             data = data["result"]
+
         return int(
-            data.get("result", {}).get("sync_info", {}).get("latest_block_height", 0)
+            data.get("sync_info", {}).get("latest_block_height", 0)
         )
+        
     # RPC endpoints can return a 200 but not JSON (usually an HTML error page due to throttling or some other error)
     # Catch everything instead of just requests.RequestException
     except Exception:
@@ -194,10 +199,15 @@ def get_block_time_rpc(rpc_url, height):
         response = requests.get(f"{rpc_url}/block?height={height}", timeout=1)
         response.raise_for_status()
         data = response.json()
-        return data.get("result", {}).get("block", {}).get("header", {}).get("time", "")
+
+        if "result" in data.keys():
+             data = data["result"]
+
+        return data.get("block", {}).get("header", {}).get("time", "")
     # RPC endpoints can return a 200 but not JSON (usually an HTML error page due to throttling or some other error)
     # Catch everything instead of just requests.RequestException
-    except Exception:
+    except Exception as e:
+        print(e)
         return None
 
 

--- a/app.py
+++ b/app.py
@@ -179,14 +179,14 @@ def get_latest_block_height_rpc(rpc_url):
         response = requests.get(f"{rpc_url}/status", timeout=1)
         response.raise_for_status()
         data = response.json()
-        
+
         if "result" in data.keys():
              data = data["result"]
 
         return int(
             data.get("sync_info", {}).get("latest_block_height", 0)
         )
-        
+
     # RPC endpoints can return a 200 but not JSON (usually an HTML error page due to throttling or some other error)
     # Catch everything instead of just requests.RequestException
     except Exception:


### PR DESCRIPTION
Add result key check to RPC time requests since some chains do not return the data with result key as the top level.

The SEI chain RPC endpoint is not returning data in the expected format. Our RPC block requests expect the "result" key to be at the top level, but they seem to have flattened the Node response so that its missing the "result".

![image](https://github.com/DefiantLabs/cosmos-upgrades/assets/24580777/5f580326-8400-474f-9261-494fe1509f1d)

Add a basic check to flatten the data ourselves for other chains.