### PR TITLE
patch/hard version Werkzeug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests==2.26.0
 urllib3==1.26.7
 gunicorn==20.1.0
 semantic-version==2.10.0
+Werkzeug==2.2.2


### PR DESCRIPTION
Version wekzeug to prevent bumping version since they do not specify the proper version they use.

Solution from here: https://stackoverflow.com/questions/77213053/importerror-cannot-import-name-url-quote-from-werkzeug-urls