### PR TITLE
Fix: Add chain-id validation to endpoint health checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,36 @@ env:
 # Removed top-level permissions block
 
 jobs:
+  validate-chain-ids:
+    name: Validate Chain-IDs in changed chain.json files
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
+      - name: Find changed chain.json files
+        id: changed
+        run: |
+          FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD \
+            | grep 'chain\.json$' || true)
+          echo "files<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$FILES" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Validate chain-ids
+        if: steps.changed.outputs.files != ''
+        run: |
+          echo "${{ steps.changed.outputs.files }}" | \
+            xargs python scripts/validate_chain_ids.py
+
   lint:
     name: Lint Code
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ cosmos-chain-registry*
 __pycache__/*
 chain-registry/
 cache/*
+
+# editor workpsace
+.idea

--- a/app.py
+++ b/app.py
@@ -345,7 +345,7 @@ def get_network_timeout(network, default_timeout, timeout_type="status"):
     return default_timeout
 
 
-def get_healthy_rpc_endpoints(rpc_endpoints, network=None):
+def get_healthy_rpc_endpoints(rpc_endpoints, network=None, expected_chain_id=None):
     # First inject private RPC endpoints if available for this network
     private_rpcs = []
     if network and network in private_endpoints and "rpc" in private_endpoints[network]:
@@ -360,7 +360,7 @@ def get_healthy_rpc_endpoints(rpc_endpoints, network=None):
         healthy_rpc_endpoints = [
             rpc
             for rpc, is_healthy in executor.map(
-                lambda rpc: (rpc, is_rpc_endpoint_healthy(rpc["address"], network)), combined_endpoints
+                lambda rpc: (rpc, is_rpc_endpoint_healthy(rpc["address"], network, expected_chain_id)), combined_endpoints
             )
             if is_healthy
         ]
@@ -373,7 +373,7 @@ def get_healthy_rpc_endpoints(rpc_endpoints, network=None):
     return healthy_rpc_endpoints[:MAX_HEALTHY_ENDPOINTS]
 
 
-def get_healthy_rest_endpoints(rest_endpoints, network=None):
+def get_healthy_rest_endpoints(rest_endpoints, network=None, expected_chain_id=None):
     # First inject private REST endpoints if available for this network
     private_rests = []
     if network and network in private_endpoints and "rest" in private_endpoints[network]:
@@ -388,7 +388,7 @@ def get_healthy_rest_endpoints(rest_endpoints, network=None):
         healthy_rest_endpoints = [
             rest
             for rest, is_healthy in executor.map(
-                lambda rest: (rest, is_rest_endpoint_healthy(rest["address"], network)),
+                lambda rest: (rest, is_rest_endpoint_healthy(rest["address"], network, expected_chain_id)),
                 combined_endpoints,
             )
             if is_healthy
@@ -402,7 +402,7 @@ def get_healthy_rest_endpoints(rest_endpoints, network=None):
     return healthy_rest_endpoints[:MAX_HEALTHY_ENDPOINTS]
 
 
-def is_rpc_endpoint_healthy(endpoint, network=None):
+def is_rpc_endpoint_healthy(endpoint, network=None, expected_chain_id=None):
     timeout = get_network_timeout(network, HEALTH_CHECK_TIMEOUT_SECONDS, "health_check")
     network_logger = logger.bind(network=network.upper() if network else "UNKNOWN", progress="")
 
@@ -414,6 +414,19 @@ def is_rpc_endpoint_healthy(endpoint, network=None):
         if response.status_code != 200:
             response = requests.get(f"{endpoint}/health", timeout=timeout, verify=False)
         result = response.status_code == 200
+
+        if result and expected_chain_id:
+            status_resp = requests.get(f"{endpoint}/status", timeout=timeout, verify=False)
+            if status_resp.status_code == 200:
+                data = status_resp.json()
+                if "result" in data:
+                    data = data["result"]
+                actual_chain_id = data.get("node_info", {}).get("network", "")
+                if actual_chain_id and actual_chain_id != expected_chain_id:
+                    network_logger.warning(
+                        f"RPC chain-id mismatch for {endpoint}: expected {expected_chain_id}, got {actual_chain_id}"
+                    )
+                    result = False
 
         if network and network.lower() in NETWORK_DIAGNOSTICS:
             duration = (datetime.now() - start_time).total_seconds()
@@ -432,7 +445,7 @@ def is_rpc_endpoint_healthy(endpoint, network=None):
         return False
 
 
-def is_rest_endpoint_healthy(endpoint, network=None):
+def is_rest_endpoint_healthy(endpoint, network=None, expected_chain_id=None):
     timeout = get_network_timeout(network, HEALTH_CHECK_TIMEOUT_SECONDS, "health_check")
     network_logger = logger.bind(network=network.upper() if network else "UNKNOWN", progress="")
 
@@ -448,6 +461,20 @@ def is_rest_endpoint_healthy(endpoint, network=None):
                 verify=False,
             )
         result = response.status_code == 200
+
+        if result and expected_chain_id:
+            node_info_resp = requests.get(
+                f"{endpoint}/cosmos/base/tendermint/v1beta1/node_info",
+                timeout=timeout,
+                verify=False,
+            )
+            if node_info_resp.status_code == 200:
+                actual_chain_id = node_info_resp.json().get("default_node_info", {}).get("network", "")
+                if actual_chain_id and actual_chain_id != expected_chain_id:
+                    network_logger.warning(
+                        f"REST chain-id mismatch for {endpoint}: expected {expected_chain_id}, got {actual_chain_id}"
+                    )
+                    result = False
 
         if network and network.lower() in NETWORK_DIAGNOSTICS:
             duration = (datetime.now() - start_time).total_seconds()
@@ -1050,6 +1077,7 @@ def reorder_data(data):
         [
             ("type", data.get("type")),
             ("network", data.get("network")),
+            ("chain_id", data.get("chain_id")),
             ("rpc_server", data.get("rpc_server")),
             ("rest_server", data.get("rest_server")),
             ("latest_block_height", data.get("latest_block_height")),
@@ -1106,6 +1134,7 @@ def fetch_data_for_network(network, network_type, repo_path, custom_logger=None,
 
     rest_endpoints = data.get("apis", {}).get("rest", [])
     rpc_endpoints = data.get("apis", {}).get("rpc", [])
+    expected_chain_id = data.get("chain_id")
 
     logo_urls = fetch_logo_urls(data)
     network_logger.trace("Fetched logo URLs", urls=logo_urls)
@@ -1117,13 +1146,13 @@ def fetch_data_for_network(network, network_type, repo_path, custom_logger=None,
 
     # Add timing for RPC endpoints health check
     rpc_health_start = datetime.now()
-    healthy_rpc_endpoints = get_healthy_rpc_endpoints(rpc_endpoints, network)
+    healthy_rpc_endpoints = get_healthy_rpc_endpoints(rpc_endpoints, network, expected_chain_id)
     rpc_health_duration = (datetime.now() - rpc_health_start).total_seconds()
     network_logger.debug(f"RPC health check took {rpc_health_duration:.2f}s, found {len(healthy_rpc_endpoints)} healthy endpoints")
 
     # Add timing for REST endpoints health check
     rest_health_start = datetime.now()
-    healthy_rest_endpoints = get_healthy_rest_endpoints(rest_endpoints, network)
+    healthy_rest_endpoints = get_healthy_rest_endpoints(rest_endpoints, network, expected_chain_id)
     rest_health_duration = (datetime.now() - rest_health_start).total_seconds()
     network_logger.debug(f"REST health check took {rest_health_duration:.2f}s, found {len(healthy_rest_endpoints)} healthy endpoints")
 
@@ -1372,6 +1401,7 @@ def fetch_data_for_network(network, network_type, repo_path, custom_logger=None,
     final_output_data = {
         "network": network,
         "type": network_type,
+        "chain_id": expected_chain_id,
         "rpc_server": rpc_server_used,
         "rest_server": rest_server_used,
         "latest_block_height": latest_block_height,

--- a/scripts/validate_chain_ids.py
+++ b/scripts/validate_chain_ids.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+CI script: verify that RPC and REST endpoints in changed chain.json files
+actually serve the chain_id declared in that file.
+
+Usage:
+    python scripts/validate_chain_ids.py path/to/chain.json [...]
+
+Exit codes:
+    0  all checked endpoints match
+    1  one or more mismatches or errors found
+"""
+
+import json
+import sys
+import urllib.request
+import urllib.error
+
+TIMEOUT = 10
+MAX_ENDPOINTS = 2  # check at most this many RPC and REST endpoints per file
+
+
+def fetch_json(url):
+    req = urllib.request.Request(url, headers={"User-Agent": "cosmos-upgrades-ci"})
+    with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
+        return json.loads(resp.read())
+
+
+def get_rpc_chain_id(rpc_url):
+    data = fetch_json(f"{rpc_url.rstrip('/')}/status")
+    result = data.get("result", data)
+    return result["node_info"]["network"]
+
+
+def get_rest_chain_id(rest_url):
+    data = fetch_json(f"{rest_url.rstrip('/')}/cosmos/base/tendermint/v1beta1/node_info")
+    return data["default_node_info"]["network"]
+
+
+def validate_file(path):
+    errors = []
+    with open(path) as f:
+        chain = json.load(f)
+
+    expected = chain.get("chain_id")
+    if not expected:
+        print(f"  SKIP  {path}: no chain_id field")
+        return []
+
+    rpc_endpoints = [e["address"] for e in chain.get("apis", {}).get("rpc", [])]
+    rest_endpoints = [e["address"] for e in chain.get("apis", {}).get("rest", [])]
+
+    for url in rpc_endpoints[:MAX_ENDPOINTS]:
+        try:
+            actual = get_rpc_chain_id(url)
+            if actual != expected:
+                errors.append(f"  FAIL  RPC {url}: expected {expected!r}, got {actual!r}")
+            else:
+                print(f"  OK    RPC {url} → {actual}")
+        except Exception as e:
+            print(f"  WARN  RPC {url}: unreachable ({e})")
+
+    for url in rest_endpoints[:MAX_ENDPOINTS]:
+        try:
+            actual = get_rest_chain_id(url)
+            if actual != expected:
+                errors.append(f"  FAIL  REST {url}: expected {expected!r}, got {actual!r}")
+            else:
+                print(f"  OK    REST {url} → {actual}")
+        except Exception as e:
+            print(f"  WARN  REST {url}: unreachable ({e})")
+
+    return errors
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: validate_chain_ids.py <chain.json> [...]")
+        sys.exit(1)
+
+    all_errors = []
+    for path in sys.argv[1:]:
+        print(f"\nChecking {path}")
+        all_errors.extend(validate_file(path))
+
+    if all_errors:
+        print("\nMismatches detected:")
+        for err in all_errors:
+            print(err)
+        sys.exit(1)
+
+    print("\nAll checked endpoints match their declared chain_id.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Fix: Add chain-id validation to endpoint health checks

- closes #49 

## Problem

The "healthy" endpoint logic only tested RPC/API liveness (HTTP 200), never verifying that an endpoint actually serves the expected network. This allowed mismatched endpoints to pass health checks silently.

**Concrete example:** `xrplevmtestnet` had its RPC pointing at `xrplevm_1449000-1` while its REST API was still on `exrp_1440002-1` (the old devnet). Because both responded with HTTP 200, both passed health checks. The upgrade plan `v8.0.0-rc.1` from the devnet then surfaced on the dashboard as belonging to the testnet — even though no such governance existed there.

## Reproduction

As the current issue has already been outdated (year old) in order to reproduce, I've made the deterministic reproduction script as `reproduce.py` to confirm the bug without depending on live endpoints being in a specific state.

The script mocks two endpoints with deliberately mismatched chain-ids:
- RPC → `xrplevm_1449000-1` (correct testnet)
- REST → `exrp_1440002-1` (wrong — devnet)

---

<details>
<summary> reproduce.py reproduction script:</summary>
<br>

```
import json
import os
import sys
import tempfile
from unittest.mock import MagicMock, patch

sys.path.insert(0, ".")

RPC_CHAIN_ID  = "xrplevm_1449000-1"   # correct testnet
REST_CHAIN_ID = "exrp_1440002-1"       # wrong — devnet (this is the bug)
BLOCK_HEIGHT  = 1_000_000
def make_response(json_data, status=200):
    m = MagicMock()
    m.status_code = status
    m.raise_for_status = lambda: None
    m.json.return_value = json_data
    return m

def mock_get(url, **kwargs):
    # RPC health check
    if "/abci_info" in url:
        return make_response({})
    # REST health check (primary)
    if url.endswith("/health"):
        return make_response({})
    # REST health check fallback + chain-id check — returns the WRONG chain-id
    if "/node_info" in url:
        return make_response({
            "default_node_info": {"network": REST_CHAIN_ID}
        })
    # Block height via RPC /status
    if "/status" in url:
        return make_response({
            "result": {
                "node_info": {"network": RPC_CHAIN_ID},
                "sync_info": {"latest_block_height": str(BLOCK_HEIGHT)},
            }
        })
    # Block time via RPC /block — called twice (current + past height)
    if "/block" in url:
        return make_response({
            "result": {
                "block": {
                    "header": {"time": "2025-05-20T12:00:00.000000000Z"}
                }
            }
        })
    # Upgrade plan on REST — belongs to devnet (exrp_1440002-1), not the testnet
    if "/cosmos/upgrade/v1beta1/current_plan" in url:
        return make_response({
            "plan": {
                "name": "v8.0.0-rc.1",
                "height": str(BLOCK_HEIGHT + 500),   # future block → will be reported
                "info": "",
            }
        })
    # Gov proposals
    if "/cosmos/gov/" in url:
        return make_response({"proposals": []})
    return make_response({})

# Minimal fake chain.json — chain_id is the expected (correct) one
FAKE_CHAIN_JSON = {
    "chain_id": RPC_CHAIN_ID,
    "codebase": {"git_repo": "https://github.com/xrplevm/node"},
    "apis": {
        "rpc":  [{"address": "http://fake-rpc.local"}],
        "rest": [{"address": "http://fake-rest.local"}],
    },
    "explorers": [],
}

tmp = tempfile.mkdtemp()
net_dir = os.path.join(tmp, "testnets", "xrplevmtestnet")
os.makedirs(net_dir)
with open(os.path.join(net_dir, "chain.json"), "w") as f:
    json.dump(FAKE_CHAIN_JSON, f)

import app as app_module

with (
    patch("requests.get", side_effect=mock_get),
    # Clear private endpoints so only our fake chain.json endpoints are used
    patch.object(app_module, "private_endpoints", {}),
    # Semver tag fetch would hit GitHub — return empty list instead
    patch.object(app_module, "get_network_repo_semver_tags", return_value=[]),
):
    result = app_module.fetch_data_for_network("xrplevmtestnet", "testnet", tmp)

print(json.dumps(result, indent=2))
print()
if result.get("upgrade_found"):
    print("BUG REPRODUCED: upgrade_found=true despite RPC/REST chain-id mismatch")
    print(f"  RPC chain-id : {RPC_CHAIN_ID}")
    print(f"  REST chain-id: {REST_CHAIN_ID}  <-- different network!")
    print(f"  upgrade_name : {result.get('upgrade_name')}")
else:
    print("Not reproduced — check errors above.")
```

</details>

- run `python reproduce.py` and can see the output `BEFORE THE FIX`

<img width="1271" height="863" alt="Screenshot 2026-06-14 at 3 27 25 PM" src="https://github.com/user-attachments/assets/efa541f3-016e-4ac1-ab1c-84530f5484bb" />

- and `AFTER THE FIX` 

<img width="1314" height="621" alt="Screenshot 2026-06-14 at 3 28 51 PM" src="https://github.com/user-attachments/assets/01eb01a2-e29f-4923-952c-a49fb8b1c23d" />

## Changes

### 1. Chain-ID validation in health checks (`app.py`)

**`is_rpc_endpoint_healthy`** — after confirming HTTP 200 liveness, queries `/status` and rejects the endpoint if `node_info.network` does not match the expected `chain_id`

**`is_rest_endpoint_healthy`** — after confirming HTTP 200 liveness, queries `/cosmos/base/tendermint/v1beta1/node_info` and rejects the endpoint if `default_node_info.network` does not match

**`get_healthy_rpc_endpoints` / `get_healthy_rest_endpoints`** — accept and thread `expected_chain_id` through to the health check functions.

**`fetch_data_for_network`** — reads `chain_id` from `chain.json` and passes it to both `get_healthy_*` calls:

### 2. Chain-ID included in upgrade output (`app.py`)

`chain_id` is now part of every network's output — both in `final_output_data` and `reorder_data` — so consumers can verify which network an upgrade plan belongs to:

```json
{
  "network": "xrplevmtestnet",
  "chain_id": "xrplevm_1449000-1",
  "upgrade_found": true,
  "upgrade_name": "v9.0.0",
  ...
}
```

### 3. API fetches gated by chain-id (covered by fix 1)

Because mismatched REST endpoints are now filtered out during the health check phase, the upgrade query loop (`for rest_endpoint in healthy_rest_endpoints`) never receives an endpoint from a different network. No additional gate is needed at the query site.

### 4. CI validation for new chain.json entries

**`scripts/validate_chain_ids.py`** — a standalone Python script (no third-party deps) that takes one or more `chain.json` paths as arguments, queries up to 2 RPC and 2 REST endpoints each, and exits non-zero on any chain-id mismatch

**`.github/workflows/ci.yml`** — new `validate-chain-ids` job that runs on every PR, finds all `chain.json` files changed in the diff, and passes them to the script. To validate the workflow change, I've tested locally with [act](https://github.com/nektos/act) and attaching the output

<img width="1509" height="764" alt="image" src="https://github.com/user-attachments/assets/e58945b3-60b2-4346-998d-a8fa368ea2fe" />

### 5. updated `.gitignore` to ignore idea related workspace